### PR TITLE
sendMessage() function in Deno

### DIFF
--- a/deno/send_message/README.md
+++ b/deno/send_message/README.md
@@ -1,0 +1,102 @@
+# SendMessage() 
+
+A sample Deno Cloud Function sending a message using a specific channel to a receiver
+
+Supported channels are `SMS`, `EMAIL` ,`DISCORD` and `TWEET`.
+
+
+_Example function payloads:_
+
+```json
+// Sending SMS
+{
+    "type":"SMS","receiver":"+123456789","message":"Programming is fun!"
+}
+// Sending Email
+{
+    "type":"EMAIL","receiver":"hello@example.com",
+    "message":"Programming is fun!","subject":"Programming is funny!"
+}
+// Sending message through Discord webhook 
+{
+    "type":"DISCORD","receiver":"","message":"Hi"
+}
+// Sending a tweet
+{
+    "type":"TWEET","receiver":"","message":"Programming is fun!"
+}
+```
+
+
+_Successful function response:_
+
+
+```json
+{ "success" : true }
+```
+
+_Error function response:_
+
+
+```json
+{
+	"success": false,
+	"error": "Failed to send message, check the webhook URL"
+}
+```
+
+## 📝 Environment Variables
+
+List of environment variables used by this cloud function:
+
+Mailgun
+* **MAILGUN_API_KEY** - API Key for Mailgun 
+* **MAILGUN_DOMAIN** - Domain Name from Mailgun
+
+Discord
+* **DISCORD_WEBHOOK_URL** - Webhook URL for Discord 
+
+Twilio 
+
+* **TWILIO_ACCOUNT_SID** - Acount SID from Twilio
+
+* **TWILIO_AUTH_TOKEN** - Auth Token from Twilio
+
+* **TWILIO_SENDER** - Sender Phone Number from Twilio
+
+Twitter
+
+* **TWITTER_API_KEY** - API Key for Twitter
+
+
+* **TWITTER_API_KEY_SECRET** - API Key Secret for Twitter
+
+* **TWITTER_ACCESS_TOKEN** - Access Token from Twitter
+
+* **TWITTER_API_KEY_SECRET** - Access Token Secret from Twitter
+
+## 🚀 Deployment
+
+1. Clone this repository, and enter this function folder:
+
+```
+$ git clone https://github.com/open-runtimes/examples.git && cd examples
+$ cd deno/send_email_with_mailgun
+```
+
+2. Enter this function folder and build the code:
+```
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=src/mod.ts --rm --interactive --tty --volume $PWD:/usr/code openruntimes/deno:1.14 sh /usr/local/src/build.sh
+```
+As a result, a `code.tar.gz` file will be generated.
+
+3. Start the Open Runtime:
+```
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_ENTRYPOINT=src/mod.ts -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/deno:1.14 sh /usr/local/src/start.sh
+```
+
+Your function is now listening on port `3000`, and you can execute it by sending `POST` request with appropriate authorization headers. To learn more about runtime, you can visit Deno runtime [README](https://github.com/open-runtimes/open-runtimes/tree/main/runtimes/deno-1.14).
+
+## 📝 Notes
+ - This function is designed for use with Appwrite Cloud Functions. You can learn more about it in [Appwrite docs](https://appwrite.io/docs/functions).
+ - This example is compatible with Deno 1.13 and 1.14. Other versions may work but are not guarenteed to work as they haven't been tested.

--- a/deno/send_message/src/functions/send_email_mailgun.ts
+++ b/deno/send_message/src/functions/send_email_mailgun.ts
@@ -1,0 +1,31 @@
+export default async function (
+  env: any,
+  email: string,
+  message: string,
+  subject: string
+) {
+  const domain = env["MAILGUN_DOMAIN"];
+  const apiKey = env["MAILGUN_API_KEY"];
+
+  const form = new FormData();
+  form.append("from", "<welcome@my-awesome-app.io>");
+  form.append("to", email);
+  form.append("subject", subject);
+  form.append("text", message);
+
+  const res = await fetch(`https://api.mailgun.net/v3/${domain}/messages`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${btoa("api:" + apiKey)}`,
+    },
+    body: form,
+  });
+  if (res.status !== 200) {
+    return {
+      success: false,
+      error: res.statusText,
+    };
+  }
+
+  return { success: true };
+}

--- a/deno/send_message/src/functions/send_message_discord_webhook.ts
+++ b/deno/send_message/src/functions/send_message_discord_webhook.ts
@@ -1,0 +1,23 @@
+export default async function (env: any, message: string) {
+  const webhook = env["DISCORD_WEBHOOK_URL"];
+  console.log(webhook);
+
+  const res = await fetch(webhook, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      content: message,
+    }),
+  });
+  if (res.status !== 204) {
+    console.log(res);
+    return {
+      success: false,
+      error: "Failed to send message, check the webhook URL",
+    };
+  }
+
+  return { success: true };
+}

--- a/deno/send_message/src/functions/send_sms_twilio.ts
+++ b/deno/send_message/src/functions/send_sms_twilio.ts
@@ -1,0 +1,29 @@
+export default async function (env: any, phoneNumber: string, message: string) {
+  const accountSID = env["TWILIO_ACCOUNT_SID"];
+  const authToken = env["TWILIO_AUTH_TOKEN"];
+  const sender = env["TWILIO_SENDER"];
+
+  const res = await fetch(
+    `https://api.twilio.com/2010-04-01/Accounts/${accountSID}/Messages.json`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${btoa(`${accountSID}:${authToken}`)}`,
+      },
+      body: new URLSearchParams({
+        To: phoneNumber,
+        From: sender,
+        Body: message,
+      }),
+    }
+  );
+
+  if (res.status !== 201) {
+    return {
+      success: false,
+      error: res.statusText,
+    };
+  }
+  return { success: true };
+}

--- a/deno/send_message/src/functions/send_tweet.ts
+++ b/deno/send_message/src/functions/send_tweet.ts
@@ -1,0 +1,29 @@
+import { statusUpdate } from "https://kamekyame.github.io/twitter_api_client/api_v1/tweets/update.ts";
+
+export default async function (env: any, text: string) {
+  const consumerKey = env["TWITTER_API_KEY"];
+  const consumerSecret = env["TWITTER_API_KEY_SECRET"];
+  const accessToken = env["TWITTER_ACCESS_TOKEN"];
+  const accessTokenSecret = env["TWITTER_ACCESS_TOKEN_SECRET"];
+
+  const res = await statusUpdate(
+    {
+      consumerKey: consumerKey,
+      consumerSecret: consumerSecret,
+      token: accessToken,
+      tokenSecret: accessTokenSecret,
+    },
+    {
+      status: text,
+    }
+  );
+
+  if (res.errors) {
+    return {
+      success: false,
+      error: res.errors[0].message,
+    };
+  }
+
+  return { success: true };
+}

--- a/deno/send_message/src/mod.ts
+++ b/deno/send_message/src/mod.ts
@@ -1,0 +1,42 @@
+import send_email_mailgun from "./functions/send_email_mailgun.ts";
+import send_sms_twilio from "./functions/send_sms_twilio.ts";
+import send_message_discord_webhook from "./functions/send_message_discord_webhook.ts";
+import send_tweet from "./functions/send_tweet.ts";
+
+export default async function (req: any, res: any) {
+  const type: string = req.payload["type"];
+
+  const receiver = req.payload?.["receiver"];
+  const message = req.payload?.["message"];
+  const subject = req.payload?.["subject"];
+
+  let response: any;
+
+  switch (type) {
+    case "EMAIL":
+      response = await send_email_mailgun(req.env, receiver, message, subject);
+      break;
+
+    case "SMS":
+      response = await send_sms_twilio(req.env, receiver, message);
+      break;
+
+    case "DISCORD":
+      response = await send_message_discord_webhook(req.env, message);
+      break;
+
+    case "TWEET":
+      response = await send_tweet(req.env, message);
+      break;
+
+    default:
+      console.log("Invalid type");
+      response = {
+        success: false,
+        error: "Invalid type",
+      };
+      break;
+  }
+
+  res.send(response);
+}


### PR DESCRIPTION


## sendMessage() function 


According to the issue [#3953](https://github.com/appwrite/appwrite/issues/3953) on appwrite,

I created a sample Deno Cloud Function for sending a message using a specific channel to a receiver

It can send mail (using mailgun), send discord messages (webhook), send a tweet, and send SMS (using Twilio)

# sample request and result


##  1. Sending SMS 

payload and response

![SendMessage() trial SMS](https://user-images.githubusercontent.com/88965873/194005616-d418dd3d-6158-46a7-bd28-697a728e6efd.png)

message received

![image](https://user-images.githubusercontent.com/88965873/194007018-4826eef3-2873-48e8-968c-6171c4b47c8d.png)

##  2. Sending Email 

payload and response

![image](https://user-images.githubusercontent.com/88965873/194012251-d6a16978-39a6-4f9c-ac2d-86c63ef3f853.png)

email received

![image](https://user-images.githubusercontent.com/88965873/194012562-57b8aaf1-2272-4460-87a6-03c57679f9a9.png)

## 3. Tweet

payload and response

![image](https://user-images.githubusercontent.com/88965873/194012082-9a679711-5a22-40d7-a4ca-bf5a45eb0f48.png)

Tweeted

![image](https://user-images.githubusercontent.com/88965873/194013505-3c437d81-5f77-4dae-9936-c63286d1bf95.png)


## 4. Sending Discord message

payload and response

![image](https://user-images.githubusercontent.com/88965873/194013940-46b1d36b-ab75-47d4-a809-e2d7349f2b4d.png)

message received 
![image](https://user-images.githubusercontent.com/88965873/194014110-a112350e-973a-47ab-9fa9-fd432c9ab6df.png)


