### PR TITLE
Added wipeAppwriteBucket() Function using PHP

### DIFF
--- a/php/wipe_appwrite_bucket/README.md
+++ b/php/wipe_appwrite_bucket/README.md
@@ -14,7 +14,15 @@ _Example output:_
 
 ```json
 {
-  "success":true
+  "success":true,
+  "sum": 3
+}
+```
+
+```json
+{
+  "success":false,
+  "message": "Could not connect to Appwrite server."
 }
 ```
 
@@ -28,14 +36,32 @@ List of environment variables used by this cloud function:
 
 ## 🚀 Deployment
 
-There are two ways of deploying the Appwrite function, both having the same results, but each using a different process. We highly recommend using CLI deployment to achieve the best experience.
+1. Clone this repository, and enter this function folder:
 
-### Using CLI
+```
+$ git clone https://github.com/open-runtimes/examples.git && cd examples
+$ cd php/wipe_appwrite_bucket
+```
 
-Make sure you have [Appwrite CLI](https://appwrite.io/docs/command-line#installation) installed, and you have successfully logged into your Appwrite server. To make sure Appwrite CLI is ready, you can use the command `appwrite client --debug` and it should respond with green text `✓ Success`.
+2. Enter this function folder and build the code:
+```
+docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:v2-8.1 sh /usr/local/src/build.sh
+```
+As a result, a `code.tar.gz` file will be generated.
 
-Make sure you are in the same folder as your `appwrite.json` file and run `appwrite deploy function` to deploy your function. You will be prompted to select which functions you want to deploy.
+3. Start the Open Runtime:
+```
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:v2-8.1 sh /usr/local/src/start.sh
+```
 
-### Manual using tar.gz
+Your function is now listening on port `3000`, and you can execute it by sending `POST` request with appropriate authorization headers. To learn more about runtime, you can visit PHP runtime [README](https://github.com/open-runtimes/open-runtimes/tree/main/runtimes/php-8.1).
 
-Manual deployment has no requirements and uses Appwrite Console to deploy the tag. First, enter the folder of your function. Then, create a tarball of the whole folder and gzip it. After creating `.tar.gz` file, visit Appwrite Console, click on the `Deploy Tag` button and switch to the `Manual` tab. There, set the `entrypoint` to `index.php`, and upload the file we just generated.
+4. Execute function:
+
+```
+curl http://localhost:3000/ -d '{"variables":{"APPWRITE_FUNCTION_ENDPOINT":"YOUR_ENDPOINT","APPWRITE_FUNCTION_PROJECT_ID":"YOUR_PROJECT_ID","APPWRITE_FUNCTION_API_KEY":"YOUR_API_KEY"},"payload":"{\"bucketId\":\"profilePictures\"}"}' -H "X-Internal-Challenge: secret-key" -H "Content-Type: application/json"
+```
+
+## 📝 Notes
+ - This function is designed for use with Appwrite Cloud Functions. You can learn more about it in [Appwrite docs](https://appwrite.io/docs/functions).
+ - This example is compatible with PHP 8.1. Other versions may work but are not guaranteed to work as they haven't been tested.

--- a/php/wipe_appwrite_bucket/README.md
+++ b/php/wipe_appwrite_bucket/README.md
@@ -1,0 +1,41 @@
+# 🗑 Wipe Appwrite Bucket
+
+A PHP cloud function to wipe a complete bucket in Appwrite by passing the bucket id as a payload.
+
+_Example input:_
+
+```json
+{
+  "bucketId":"profilePictures"
+}
+```
+
+_Example output:_
+
+```json
+{
+  "success":true
+}
+```
+
+## 📝 Environment Variables
+
+List of environment variables used by this cloud function:
+
+- **APPWRITE_FUNCTION_ENDPOINT** - Endpoint of Appwrite project
+- **APPWRITE_FUNCTION_API_KEY** - Appwrite API Key
+- **APPWRITE_FUNCTION_PROJECT_ID** - Appwrite project ID. If running on Appwrite, this variable is provided automatically.
+
+## 🚀 Deployment
+
+There are two ways of deploying the Appwrite function, both having the same results, but each using a different process. We highly recommend using CLI deployment to achieve the best experience.
+
+### Using CLI
+
+Make sure you have [Appwrite CLI](https://appwrite.io/docs/command-line#installation) installed, and you have successfully logged into your Appwrite server. To make sure Appwrite CLI is ready, you can use the command `appwrite client --debug` and it should respond with green text `✓ Success`.
+
+Make sure you are in the same folder as your `appwrite.json` file and run `appwrite deploy function` to deploy your function. You will be prompted to select which functions you want to deploy.
+
+### Manual using tar.gz
+
+Manual deployment has no requirements and uses Appwrite Console to deploy the tag. First, enter the folder of your function. Then, create a tarball of the whole folder and gzip it. After creating `.tar.gz` file, visit Appwrite Console, click on the `Deploy Tag` button and switch to the `Manual` tab. There, set the `entrypoint` to `index.php`, and upload the file we just generated.

--- a/php/wipe_appwrite_bucket/composer.json
+++ b/php/wipe_appwrite_bucket/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "user/function",
+    "description": "",
+    "type": "library",
+    "license": "ISC",
+    "authors": [],
+    "require": {
+        "php": ">=8.0.0",
+        "appwrite/appwrite": "7.0.*"
+    }
+}

--- a/php/wipe_appwrite_bucket/index.php
+++ b/php/wipe_appwrite_bucket/index.php
@@ -48,15 +48,23 @@ return function ($req, $res) {
         ->setKey($req['variables']['APPWRITE_FUNCTION_API_KEY']);
 
     $done = false;
-    while (!$done) {
-        $files = $storage->listFiles($bucketId)['files'];
-        foreach ($files as $file) {
-            $storage->deleteFile($bucketId, $file['$id']);
-        }
+    try {
+        while (!$done) {
+            $files = $storage->listFiles($bucketId)['files'];
+            foreach ($files as $file) {
+                $storage->deleteFile($bucketId, $file['$id']);
+            }
 
-        if (count($files) == 0) {
-            $done = true;
+            if (count($files) == 0) {
+                $done = true;
+            }
         }
+    } catch(\Exception $err) {
+        $res->json([
+            'success' => false,
+            'message' => $err->getMessage()
+        ]);
+        return;
     }
 
     // Return success result

--- a/php/wipe_appwrite_bucket/index.php
+++ b/php/wipe_appwrite_bucket/index.php
@@ -34,7 +34,7 @@ return function ($req, $res) {
        !$req['variables']['APPWRITE_FUNCTION_API_KEY']) {
         $res->json([
             'success' => false,
-            'message' => 'Please provide all required environment variables.'
+            'message' => 'Please provide all required variables.'
         ]);
         return;
     }
@@ -48,11 +48,13 @@ return function ($req, $res) {
         ->setKey($req['variables']['APPWRITE_FUNCTION_API_KEY']);
 
     $done = false;
+    $sum = 0;
     try {
         while (!$done) {
             $files = $storage->listFiles($bucketId)['files'];
             foreach ($files as $file) {
                 $storage->deleteFile($bucketId, $file['$id']);
+                $sum++;
             }
 
             if (count($files) == 0) {
@@ -69,6 +71,7 @@ return function ($req, $res) {
 
     // Return success result
     $res->json([
-        'success' => true
+        'success' => true,
+        'sum' => $sum
     ]);
 };

--- a/php/wipe_appwrite_bucket/index.php
+++ b/php/wipe_appwrite_bucket/index.php
@@ -1,0 +1,59 @@
+<?php
+
+require_once('vendor/autoload.php');
+
+use Appwrite\Client;
+use Appwrite\Services\Storage;
+
+return function ($req, $res) {
+    // Input validation
+    $bucketId = null;
+    try {
+        $payload = \json_decode($req['payload'], true);
+        $bucketId = \trim($payload['bucketId']);
+    } catch(\Exception $err) {
+        \var_dump($err);
+        $res->json([
+            'success' => false,
+            'message' => 'Payload is invalid.'
+        ]);
+        return;
+    }
+
+    if(empty($bucketId)) {
+        $res->json([
+            'success' => false,
+            'message' => 'Invalid bucket id.'
+        ]);
+        return;
+    }
+
+    // Make sure we have envirnment variables required to execute
+    if(!$req['variables']['APPWRITE_FUNCTION_ENDPOINT'] ||
+       !$req['variables']['APPWRITE_FUNCTION_PROJECT_ID'] ||
+       !$req['variables']['APPWRITE_FUNCTION_API_KEY']) {
+        $res->json([
+            'success' => false,
+            'message' => 'Please provide all required environment variables.'
+        ]);
+        return;
+    }
+
+    $client = new Client();
+    $storage = new Storage($client);
+
+    $client
+        ->setEndpoint($req['variables']['APPWRITE_FUNCTION_ENDPOINT'])
+        ->setProject($req['variables']['APPWRITE_FUNCTION_PROJECT_ID'])
+        ->setKey($req['variables']['APPWRITE_FUNCTION_API_KEY']);
+
+    $files = $storage->listFiles($bucketId)['files'];
+    foreach ($files as $file) {
+        $storage->deleteFile($bucketId, $file['$id']);
+    }
+
+    // Return success result
+    $res->json([
+        'success' => true
+    ]);
+};

--- a/php/wipe_appwrite_bucket/index.php
+++ b/php/wipe_appwrite_bucket/index.php
@@ -47,9 +47,16 @@ return function ($req, $res) {
         ->setProject($req['variables']['APPWRITE_FUNCTION_PROJECT_ID'])
         ->setKey($req['variables']['APPWRITE_FUNCTION_API_KEY']);
 
-    $files = $storage->listFiles($bucketId)['files'];
-    foreach ($files as $file) {
-        $storage->deleteFile($bucketId, $file['$id']);
+    $done = false;
+    while (!$done) {
+        $files = $storage->listFiles($bucketId)['files'];
+        foreach ($files as $file) {
+            $storage->deleteFile($bucketId, $file['$id']);
+        }
+
+        if (count($files) == 0) {
+            $done = true;
+        }
     }
 
     // Return success result


### PR DESCRIPTION
#### Summary
This PR adds an example for PHP to wipe all files in an Appwrite bucket.

#### Screens
Bucket with existing files
![screen-sel-221005-2228-06](https://user-images.githubusercontent.com/12299813/194149595-2a7831a6-0d80-41a7-8ff7-7646e2379bb0.png)
Executing function with payload
![screen-sel-221005-2228-42](https://user-images.githubusercontent.com/12299813/194149613-33f8eb7e-f3c4-4e4d-98b4-18d0b3b20c6d.png)
Function response
![screen-sel-221005-2228-51](https://user-images.githubusercontent.com/12299813/194149627-6d67d35d-e375-4899-8724-a8030138f2a1.png)
Bucket after executing the function
![screen-sel-221005-2228-59](https://user-images.githubusercontent.com/12299813/194149811-24753f12-0523-4c53-a305-69cd34d77a2d.png)
Function response when passing a payload without bucket id
![screen-sel-221005-2241-14](https://user-images.githubusercontent.com/12299813/194149884-d72943c7-11fe-4951-a24b-a675c2e4edbf.png)

#### Ticket Link

Fixes https://github.com/appwrite/appwrite/issues/4117