### PR TITLE
Add PHP Send Message example

### DIFF
--- a/php/send_message/README.md
+++ b/php/send_message/README.md
@@ -1,0 +1,115 @@
+# 📬 Send Message using a specific channel.
+
+An PHP Cloud Function sending a message using a specific channel.
+
+This example includes the following channels, `SMS`, `Email`, `Twitter`, and `Discord`.
+
+*Example input: (SMS)*
+
+```json
+{
+  "type": "SMS",
+  "receiver": "+123456789",
+  "message": "Programming is fun!"
+}
+
+```
+*Example input: (Email)*
+
+```json
+{
+  "type": "Email",
+  "receiver": "user@example.app",
+  "subject": "Welcome to the work of Cloud Functions",
+  "message": "Email sent from a PHP Cloud Function. 👀"
+}
+```
+
+```
+*Example input: (Twitter)*
+
+```json
+{
+  "type": "Twitter",
+  "message": "Tweet sent from a PHP Cloud Function. 🐦"
+}
+```
+
+```
+*Example input: (Discord)*
+
+```json
+{
+  "type": "Discord",
+  "message": "Message sent from a PHP Cloud Function. 😏"
+}
+```
+
+*Example output: (Success)*
+
+```json
+{
+  "success": true
+}
+```
+
+*Example output: (Failure)*
+
+```json
+{
+  "success": false,
+  "message": "Receiver is not a valid email."
+}
+```
+
+## 📝 Environment Variables
+
+List of environment variables used by this cloud function:
+
+#### Mailgun
+
+- **MAILGUN_API_KEY** - API Key for Mailgun 
+- **MAILGUN_DOMAIN** - Domain Name from Mailgun
+
+#### Discord
+
+- **DISCORD_WEBHOOK_URL** - Webhook URL for Discord 
+
+#### Twilio
+
+- **TWILIO_ACCOUNT_SID** - Acount SID from Twilio
+- **TWILIO_AUTH_TOKEN** - Auth Token from Twilio
+- **TWILIO_SENDER** - Sender Phone Number from Twilio
+
+#### Twitter
+
+- **TWITTER_API_KEY** - API Key for Twitter
+- **TWITTER_API_KEY_SECRET** - API Key Secret for Twitter
+- **TWITTER_ACCESS_TOKEN** - Access Token from Twitter
+- **TWITTER_ACCESS_KEY_SECRET** - Access Token Secret from Twitter
+
+## 🚀 Deployment
+
+1. Clone this repository, and enter this function folder:
+
+```
+$ git clone https://github.com/open-runtimes/examples.git && cd examples
+$ cd php/send_message
+```
+
+2. Enter this function folder and build the code:
+```
+docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:v2-8.1 sh /usr/local/src/build.sh
+```
+As a result, a `code.tar.gz` file will be generated.
+
+3. Start the Open Runtime:
+```
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:v2-8.1 sh /usr/local/src/start.sh
+```
+
+Your function is now listening on port `3000`, and you can execute it by sending `POST` request with appropriate authorization headers. To learn more about runtime, you can visit PHP runtime [README](https://github.com/open-runtimes/open-runtimes/tree/main/runtimes/php-8.1).
+
+## 📝 Notes
+ - This function is designed for use with Appwrite Cloud Functions. You can learn more about it in [Appwrite docs](https://appwrite.io/docs/functions).
+ - This example is compatible with PHP 8.1. Other versions may work but are not guaranteed to work as they haven't been tested.

--- a/php/send_message/README.md
+++ b/php/send_message/README.md
@@ -60,9 +60,9 @@ This example includes the following channels, `SMS`, `Email`, `Twitter`, and `Di
 }
 ```
 
-## 📝 Environment Variables
+## 📝 Variables
 
-List of environment variables used by this cloud function:
+List of variables used by this cloud function:
 
 #### Mailgun
 

--- a/php/send_message/README.md
+++ b/php/send_message/README.md
@@ -12,8 +12,8 @@ This example includes the following channels, `SMS`, `Email`, `Twitter`, and `Di
   "receiver": "+123456789",
   "message": "Programming is fun!"
 }
-
 ```
+
 *Example input: (Email)*
 
 ```json
@@ -25,7 +25,6 @@ This example includes the following channels, `SMS`, `Email`, `Twitter`, and `Di
 }
 ```
 
-```
 *Example input: (Twitter)*
 
 ```json
@@ -35,7 +34,6 @@ This example includes the following channels, `SMS`, `Email`, `Twitter`, and `Di
 }
 ```
 
-```
 *Example input: (Discord)*
 
 ```json

--- a/php/send_message/composer.json
+++ b/php/send_message/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "opr/send-message",
+  "description": "An example PHP Cloud Function sending a message using a specific channel to a receiver",
+  "type": "project",
+  "require": {
+      "guzzlehttp/guzzle": "^7.5",
+      "guzzlehttp/oauth-subscriber": "^0.6.0"
+  },
+  "license": "ISC",
+  "minimum-stability": "stable"
+}

--- a/php/send_message/index.php
+++ b/php/send_message/index.php
@@ -19,24 +19,10 @@ return function($req, $res) {
     };
 
     $notificator = match (strtolower($payload['type'])) {
-        'sms' => new SMSChannel(
-            $req['variables']['TWILIO_ACCOUNT_SID'],
-            $req['variables']['TWILIO_AUTH_TOKEN'],
-            $req['variables']['TWILIO_SENDER'],
-        ),
-        'email' => new EmailChannel(
-            $req['variables']['MAILGUN_API_KEY'],
-            $req['variables']['MAILGUN_DOMAIN'],
-        ),
-        'twitter' => new TwitterChannel(
-            $req['variables']['TWITTER_API_KEY'],
-            $req['variables']['TWITTER_API_KEY_SECRET'],
-            $req['variables']['TWITTER_ACCESS_TOKEN'],
-            $req['variables']['TWITTER_ACCESS_KEY_SECRET'],
-        ),
-        'discord' => new DiscordChannel(
-            $req['variables']['DISCORD_WEBHOOK_URL'],
-        ),
+        'sms' => new SMSChannel($req['variables']),
+        'email' => new EmailChannel($req['variables']),
+        'twitter' => new TwitterChannel($req['variables']),
+        'discord' => new DiscordChannel($req['variables']),
         default => new NullChannel,
     };
 

--- a/php/send_message/index.php
+++ b/php/send_message/index.php
@@ -18,6 +18,13 @@ return function($req, $res) {
         ]);
     };
 
+    if (!array_key_exists('type', $payload)) {
+        return $res->json([
+            'status' => false,
+            'message' => "Invalid payload, object 'type' is required."
+        ]);
+    }
+
     $notificator = match (strtolower($payload['type'])) {
         'sms' => new SMSChannel($req['variables']),
         'email' => new EmailChannel($req['variables']),

--- a/php/send_message/index.php
+++ b/php/send_message/index.php
@@ -1,0 +1,48 @@
+<?php
+
+require 'vendor/autoload.php';
+
+include_once 'src/DiscordChannel.php';
+include_once 'src/SMSChannel.php';
+include_once 'src/EmailChannel.php';
+include_once 'src/TwitterChannel.php';
+include_once 'src/NullChannel.php';
+
+return function($req, $res) {
+    try {
+        $payload = \json_decode($req['payload'], true);
+    } catch (\Exception $error) {
+        $res->json([
+            'status' => false,
+            'message' => $error->getMessage(),
+        ]);
+    };
+
+    $notificator = match (strtolower($payload['type'])) {
+        'sms' => new SMSChannel(
+            $req['variables']['TWILIO_ACCOUNT_SID'],
+            $req['variables']['TWILIO_AUTH_TOKEN'],
+            $req['variables']['TWILIO_SENDER'],
+        ),
+        'email' => new EmailChannel(
+            $req['variables']['MAILGUN_API_KEY'],
+            $req['variables']['MAILGUN_DOMAIN'],
+        ),
+        'twitter' => new TwitterChannel(
+            $req['variables']['TWITTER_API_KEY'],
+            $req['variables']['TWITTER_API_KEY_SECRET'],
+            $req['variables']['TWITTER_ACCESS_TOKEN'],
+            $req['variables']['TWITTER_ACCESS_KEY_SECRET'],
+        ),
+        'discord' => new DiscordChannel(
+            $req['variables']['DISCORD_WEBHOOK_URL'],
+        ),
+        default => new NullChannel,
+    };
+
+    $res->json(
+        json: $notificator->send(
+            payload: $payload,
+        ),
+    );
+};

--- a/php/send_message/index.php
+++ b/php/send_message/index.php
@@ -11,10 +11,10 @@ include_once 'src/NullChannel.php';
 return function($req, $res) {
     try {
         $payload = \json_decode($req['payload'], true);
-    } catch (\Exception $error) {
+    } catch (\Exception $e) {
         $res->json([
             'status' => false,
-            'message' => $error->getMessage(),
+            'message' => $e->getMessage(),
         ]);
     };
 

--- a/php/send_message/src/Contracts/Channel.php
+++ b/php/send_message/src/Contracts/Channel.php
@@ -1,0 +1,6 @@
+<?php
+
+interface Channel
+{
+    public function send(array $payload): array;
+}

--- a/php/send_message/src/Contracts/Validator.php
+++ b/php/send_message/src/Contracts/Validator.php
@@ -1,0 +1,6 @@
+<?php
+
+interface Validator
+{
+    public function validate(string $receiver): bool;
+}

--- a/php/send_message/src/DiscordChannel.php
+++ b/php/send_message/src/DiscordChannel.php
@@ -11,7 +11,7 @@ final class DiscordChannel implements Channel
     private Client $client;
 
     public function __construct(
-        private readonly string $endpoint,
+        private readonly array $environment,
     ) {
         $this->client = new Client(
             config: [
@@ -22,13 +22,30 @@ final class DiscordChannel implements Channel
         );
     }
 
+    public function hasEnvironmentVariables(): string
+    {
+        return array_key_exists('DISCORD_WEBHOOK_URL', $this->environment);
+    }
+
+    public function getEndpoint(): string
+    {
+        return $this->environment['DISCORD_WEBHOOK_URL'];
+    }
+
     public function send(array $payload): array
     {
+        if (! $this->hasEnvironmentVariables()) {
+            return [
+                'success' => false,
+                'message' => 'Environment variables are not set.',
+            ];
+        }
+
         try {
             $response = $this->client->send(
                 request: new Request(
                     method: 'POST',
-                    uri: $this->endpoint,
+                    uri: $this->getEndpoint(),
                 ),
                 options: [
                     RequestOptions::JSON => [

--- a/php/send_message/src/DiscordChannel.php
+++ b/php/send_message/src/DiscordChannel.php
@@ -1,0 +1,50 @@
+<?php
+
+include_once 'Contracts/Channel.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
+
+final class DiscordChannel implements Channel
+{
+    private Client $client;
+
+    public function __construct(
+        private readonly string $endpoint,
+    ) {
+        $this->client = new Client(
+            config: [
+                'headers' => [
+                    'content-type' => 'application/json',
+                ]
+            ]
+        );
+    }
+
+    public function send(array $payload): array
+    {
+        try {
+            $response = $this->client->send(
+                request: new Request(
+                    method: 'POST',
+                    uri: $this->endpoint,
+                ),
+                options: [
+                    RequestOptions::JSON => [
+                        'content' => $payload['message'],
+                    ],
+                ],
+            );
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => (200 <= $response->getStatusCode() && $response->getStatusCode() < 300),
+        ];
+    }
+}

--- a/php/send_message/src/EmailChannel.php
+++ b/php/send_message/src/EmailChannel.php
@@ -1,0 +1,65 @@
+<?php
+
+include_once 'Validators/EmailValidator.php';
+include_once 'Contracts/Channel.php';
+include_once 'Traits/HasReceiver.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
+
+final class EmailChannel implements Channel
+{
+    use HasReceiver;
+    
+    protected Client $client;
+
+    public function __construct(
+        private readonly string $apiKey,
+        private readonly string $domain,
+    ) {
+        $this->client = new Client;
+    }
+
+    public function send(array $payload): array
+    {
+        if (! $this->validate(
+            validator: new EmailValidator,
+            receiver: $payload['receiver'],
+        )) {
+            return [
+                'success' => false,
+                'message' => 'Receiver is not a valid email.',
+            ];
+        }
+
+        try {
+            $response = $this->client->send(
+                request: new Request(
+                    method: 'POST',
+                    uri: sprintf('https://api.mailgun.net/v3/%s/messages', $this->domain),
+                    headers: [
+                        'authorization' => sprintf('Basic %s', base64_encode(sprintf('api:%s', $this->apiKey))),
+                    ]
+                ),
+                options: [
+                    RequestOptions::FORM_PARAMS => [
+                        'from'    => "SendMessage <mailgun@{$this->domain}>",
+                        'to'      => $payload['receiver'],
+                        'subject' => $payload['subject'],
+                        'text'    => $payload['message'],
+                    ],
+                ],
+            );
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => (200 <= $response->getStatusCode() && $response->getStatusCode() < 300),
+        ];
+    }
+}

--- a/php/send_message/src/EmailChannel.php
+++ b/php/send_message/src/EmailChannel.php
@@ -15,14 +15,36 @@ final class EmailChannel implements Channel
     protected Client $client;
 
     public function __construct(
-        private readonly string $apiKey,
-        private readonly string $domain,
+        private readonly array $environment,
     ) {
         $this->client = new Client;
     }
 
+    public function hasEnvironmentVariables(): string
+    {
+        return array_key_exists('MAILGUN_API_KEY', $this->environment)
+            && array_key_exists('MAILGUN_DOMAIN', $this->environment);
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->environment['MAILGUN_API_KEY'];
+    }
+
+    public function getDomain(): string
+    {
+        return $this->environment['MAILGUN_DOMAIN'];
+    }
+
     public function send(array $payload): array
     {
+        if (! $this->hasEnvironmentVariables()) {
+            return [
+                'success' => false,
+                'message' => 'Environment variables are not set.',
+            ];
+        }
+
         if (! $this->validate(
             validator: new EmailValidator,
             receiver: $payload['receiver'],
@@ -37,14 +59,14 @@ final class EmailChannel implements Channel
             $response = $this->client->send(
                 request: new Request(
                     method: 'POST',
-                    uri: sprintf('https://api.mailgun.net/v3/%s/messages', $this->domain),
+                    uri: sprintf('https://api.mailgun.net/v3/%s/messages', $this->getDomain()),
                     headers: [
-                        'authorization' => sprintf('Basic %s', base64_encode(sprintf('api:%s', $this->apiKey))),
+                        'authorization' => sprintf('Basic %s', base64_encode(sprintf('api:%s', $this->getApiKey()))),
                     ]
                 ),
                 options: [
                     RequestOptions::FORM_PARAMS => [
-                        'from'    => "SendMessage <mailgun@{$this->domain}>",
+                        'from'    => sprintf('SendMessage <mailgun@%s>', $this->getDomain()),
                         'to'      => $payload['receiver'],
                         'subject' => $payload['subject'],
                         'text'    => $payload['message'],

--- a/php/send_message/src/NullChannel.php
+++ b/php/send_message/src/NullChannel.php
@@ -1,0 +1,14 @@
+<?php
+
+include_once 'Contracts/Channel.php';
+
+final class NullChannel implements Channel
+{
+    public function send(array $payload): array
+    {
+        return [
+            'success' => false,
+            'message' => 'No channel type found.',
+        ];
+    }
+}

--- a/php/send_message/src/SMSChannel.php
+++ b/php/send_message/src/SMSChannel.php
@@ -1,0 +1,77 @@
+<?php
+
+include_once 'Validators/PhoneNumberValidator.php';
+include_once 'Contracts/Channel.php';
+include_once 'Traits/HasReceiver.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
+
+final class SMSChannel implements Channel
+{
+    use HasReceiver;
+
+    private Client $client;
+
+    public function __construct(
+        private readonly string $SID,
+        private readonly string $token,
+        private readonly string $phoneNumber,
+    ) {
+        $this->client = new Client;
+    }
+
+    public function send(array $payload): array
+    {
+        if (! $this->validate(
+            validator: new PhoneNumberValidator(
+                client: $this->client,
+                SID: $this->SID,
+                token: $this->token,
+            ),
+            receiver: $payload['receiver'],
+        )) {
+            return [
+                'success' => false,
+                'message' => 'Receiver is not a valid phone number.',
+            ];
+        }
+
+        try {
+            $response = $this->client->send(
+                request: new Request(
+                    method: 'POST',
+                    uri: sprintf('https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json', rawurlencode($this->SID)),
+                    headers: [
+                        'content-type'  => 'application/x-www-form-urlencoded',
+                    ],
+                ),
+                options: [
+                    RequestOptions::BODY => Query::build(
+                        params: [
+                            'To'   => $payload['receiver'],
+                            'From' => $this->phoneNumber,
+                            'Body' => $payload['message'],
+                        ],
+                        encoding: PHP_QUERY_RFC1738,
+                    ),
+                    RequestOptions::AUTH => [
+                        $this->SID, $this->token,
+                    ],
+                    RequestOptions::ALLOW_REDIRECTS => false,
+                ],
+            );
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => (200 <= $response->getStatusCode() && $response->getStatusCode() < 300),
+        ];
+    }
+}

--- a/php/send_message/src/Traits/HasReceiver.php
+++ b/php/send_message/src/Traits/HasReceiver.php
@@ -1,0 +1,11 @@
+<?php
+
+include_once __DIR__.'/../Contracts/Validator.php';
+
+trait HasReceiver
+{
+    public function validate(Validator $validator, string $receiver): ?string
+    {
+        return $validator->validate($receiver);
+    }
+}

--- a/php/send_message/src/TwitterChannel.php
+++ b/php/send_message/src/TwitterChannel.php
@@ -10,28 +10,55 @@ use GuzzleHttp\Subscriber\Oauth\Oauth1;
 
 final class TwitterChannel implements Channel
 {
-    private Client $client;
-
     public function __construct(
-        private readonly string $consumerKey,
-        private readonly string $consumerSecret,
-        private readonly string $tokenKey,
-        private readonly string $tokenSecret,
+        private readonly array $environment,
     ) {
+    }
+
+    public function hasEnvironmentVariables(): string
+    {
+        return array_key_exists('TWITTER_API_KEY', $this->environment)
+            && array_key_exists('TWITTER_API_KEY_SECRET', $this->environment)
+            && array_key_exists('TWITTER_ACCESS_TOKEN', $this->environment)
+            && array_key_exists('TWITTER_ACCESS_KEY_SECRET', $this->environment);
+    }
+
+    public function getConsumerKey(): string
+    {
+        return $this->environment['TWITTER_API_KEY'];
+    }
+
+    public function getConsumerSecret(): string
+    {
+        return $this->environment['TWITTER_API_KEY_SECRET'];
+    }
+
+    public function getTokenKey(): string
+    {
+        return $this->environment['TWITTER_ACCESS_TOKEN'];
+    }
+
+    public function getTokenSecret(): string
+    {
+        return $this->environment['TWITTER_ACCESS_KEY_SECRET'];
+    }
+
+    public function client(): Client
+    {
         $stack = HandlerStack::create();
 
         $stack->push(
             middleware: new Oauth1(
                 config: [
-                    'consumer_key'    => $consumerKey,
-                    'consumer_secret' => $consumerSecret,
-                    'token'           => $tokenKey,
-                    'token_secret'    => $tokenSecret,
+                    'consumer_key'    => $this->getConsumerKey(),
+                    'consumer_secret' => $this->getConsumerSecret(),
+                    'token'           => $this->getTokenKey(),
+                    'token_secret'    => $this->getTokenSecret(),
                 ]
             ),
         );
 
-        $this->client = new Client(
+        return new Client(
             config: [
                 'handler' => $stack,
             ],
@@ -40,8 +67,15 @@ final class TwitterChannel implements Channel
 
     public function send(array $payload): array
     {
+        if (! $this->hasEnvironmentVariables()) {
+            return [
+                'success' => false,
+                'message' => 'Environment variables are not set.',
+            ];
+        }
+
         try {
-            $response = $this->client->send(
+            $response = $this->client()->send(
                 request: new Request(
                     method: 'POST',
                     uri: 'https://api.twitter.com/1.1/statuses/update.json'

--- a/php/send_message/src/TwitterChannel.php
+++ b/php/send_message/src/TwitterChannel.php
@@ -1,0 +1,67 @@
+<?php
+
+include_once 'Contracts/Channel.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Subscriber\Oauth\Oauth1;
+
+final class TwitterChannel implements Channel
+{
+    private Client $client;
+
+    public function __construct(
+        private readonly string $consumerKey,
+        private readonly string $consumerSecret,
+        private readonly string $tokenKey,
+        private readonly string $tokenSecret,
+    ) {
+        $stack = HandlerStack::create();
+
+        $stack->push(
+            middleware: new Oauth1(
+                config: [
+                    'consumer_key'    => $consumerKey,
+                    'consumer_secret' => $consumerSecret,
+                    'token'           => $tokenKey,
+                    'token_secret'    => $tokenSecret,
+                ]
+            ),
+        );
+
+        $this->client = new Client(
+            config: [
+                'handler' => $stack,
+            ],
+        );
+    }
+
+    public function send(array $payload): array
+    {
+        try {
+            $response = $this->client->send(
+                request: new Request(
+                    method: 'POST',
+                    uri: 'https://api.twitter.com/1.1/statuses/update.json'
+                ),
+                options: [
+                    RequestOptions::QUERY => [
+                        'status' => $payload['message'],
+                    ],
+                    RequestOptions::AUTH => 'oauth',
+                ],
+            );
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => (200 <= $response->getStatusCode() && $response->getStatusCode() < 300),
+        ];
+    }
+}

--- a/php/send_message/src/Validators/EmailValidator.php
+++ b/php/send_message/src/Validators/EmailValidator.php
@@ -1,0 +1,11 @@
+<?php
+
+include_once __DIR__.'/../Contracts/Validator.php';
+
+final class EmailValidator implements Validator
+{
+    public function validate(string $receiver): bool
+    {
+        return !!filter_var($receiver, FILTER_VALIDATE_EMAIL);
+    }
+}

--- a/php/send_message/src/Validators/PhoneNumberValidator.php
+++ b/php/send_message/src/Validators/PhoneNumberValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+include_once __DIR__.'/../Contracts/Validator.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
+
+final class PhoneNumberValidator implements Validator
+{
+    public function __construct(
+        private readonly Client $client,
+        private readonly string $SID,
+        private readonly string $token,
+    ) {
+    }
+
+    public function validate(string $receiver): bool
+    {
+        try {
+            $response = $this->client->send(
+                request: new Request(
+                    method: 'GET',
+                    uri: sprintf('https://lookups.twilio.com/v1/PhoneNumbers/%s', rawurlencode($receiver)),
+                ),
+                options: [
+                    RequestOptions::AUTH => [
+                        $this->SID, $this->token,
+                    ],
+                    RequestOptions::ALLOW_REDIRECTS => false,
+                ],
+            );
+        } catch (\Exception) {
+            return false;
+        }
+
+        return $response->getStatusCode() === 200;
+    }
+}


### PR DESCRIPTION
This PR adds a PHP version of the `sendMessage()` example as described in (https://github.com/appwrite/appwrite/issues/3955).

The PR uses the same channels and services as the other send messages PRs, that way the examples will be consistent with each other. Services used are `Mailgun` and `Twilio`.

Hope the PR is satisfactory, looking forward to the review. 🙂 Screenshots are included below. 👍

I could not get autoloading inside the function to work, therefore I had to use `include_once` instead. I tried `PSR-4` and `classmap`, but the runtime refused to find the files in `src`, even though they were copied to the `.tar` successfully by Docker. Might be something to look further into at a later date.

<details><summary><strong>Screenshots of working function.</strong>
</summary>

### SMS

*Image resized*

![phone-resized](https://user-images.githubusercontent.com/2221746/194641094-c4f59be9-c816-469e-a123-73b3be65f2b3.png)

### Email

![Screen Shot 2022-10-07 at 9 09 34 PM](https://user-images.githubusercontent.com/2221746/194640235-bcd2529f-81f2-4260-82b1-2dd9671b9787.png)

### Twitter

![Screen Shot 2022-10-07 at 8 56 39 PM](https://user-images.githubusercontent.com/2221746/194640243-0f41b240-70fb-495a-855a-eb75bd88df99.png)

### Discord

![Screen Shot 2022-10-07 at 8 43 38 PM](https://user-images.githubusercontent.com/2221746/194640245-e8bd3ce8-5d32-4152-9836-e019430a93d5.png)

</details>


Closes https://github.com/appwrite/appwrite/issues/3955