### PR TITLE
Added wipeAppwriteBucket() Function using Ruby

### DIFF
--- a/ruby/wipe-appwrite-bucket/Gemfile
+++ b/ruby/wipe-appwrite-bucket/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'appwrite'

--- a/ruby/wipe-appwrite-bucket/README.md
+++ b/ruby/wipe-appwrite-bucket/README.md
@@ -27,9 +27,9 @@ _Example error output:_
 }
 ```
 
-## 📝 Environment Variables
+## 📝 Variables
 
-List of environment variables used by this cloud function:
+List of variables used by this cloud function:
 
 - **APPWRITE_FUNCTION_ENDPOINT** - Endpoint of Appwrite project
 - **APPWRITE_FUNCTION_API_KEY** - Appwrite API Key

--- a/ruby/wipe-appwrite-bucket/README.md
+++ b/ruby/wipe-appwrite-bucket/README.md
@@ -1,0 +1,50 @@
+# 🗑 Wipe Appwrite Bucket
+
+A Ruby cloud function to wipe a complete bucket in Appwrite by passing the bucket id as a payload.
+
+_Example input:_
+
+```json
+{
+  "bucketId":"profilePictures"
+}
+```
+
+_Example output:_
+
+```json
+{
+  "success":true
+}
+```
+
+_Example error output:_
+
+```json
+{
+  "success":false,
+  "message":"bucketId was not provided."
+}
+```
+
+## 📝 Environment Variables
+
+List of environment variables used by this cloud function:
+
+- **APPWRITE_FUNCTION_ENDPOINT** - Endpoint of Appwrite project
+- **APPWRITE_FUNCTION_API_KEY** - Appwrite API Key
+- **APPWRITE_FUNCTION_PROJECT_ID** - Appwrite project ID. If running on Appwrite, this variable is provided automatically.
+
+## 🚀 Deployment
+
+There are two ways of deploying the Appwrite function, both having the same results, but each using a different process. We highly recommend using CLI deployment to achieve the best experience.
+
+### Using CLI
+
+Make sure you have [Appwrite CLI](https://appwrite.io/docs/command-line#installation) installed, and you have successfully logged into your Appwrite server. To make sure Appwrite CLI is ready, you can use the command `appwrite client --debug` and it should respond with green text `✓ Success`.
+
+Make sure you are in the same folder as your `appwrite.json` file and run `appwrite deploy function` to deploy your function. You will be prompted to select which functions you want to deploy.
+
+### Manual using tar.gz
+
+Manual deployment has no requirements and uses Appwrite Console to deploy the tag. First, enter the folder of your function. Then, create a tarball of the whole folder and gzip it. After creating `.tar.gz` file, visit Appwrite Console, click on the `Deploy Tag` button and switch to the `Manual` tab. There, set the `entrypoint` to `index.rb`, and upload the file we just generated.

--- a/ruby/wipe-appwrite-bucket/index.rb
+++ b/ruby/wipe-appwrite-bucket/index.rb
@@ -1,0 +1,55 @@
+require 'appwrite'
+
+def main(req, res)
+  client = Appwrite::Client.new
+  storage = Appwrite::Storage.new(client)
+
+  if !req.variables['APPWRITE_FUNCTION_ENDPOINT'] or !req.variables['APPWRITE_FUNCTION_API_KEY']
+    return res.json({
+      :success => false,
+      :message => 'Environment variables are not set. Function cannot use Appwrite SDK.',
+    })
+  end
+
+  bucket_id = nil
+  begin
+    payload = JSON.parse(req.payload)
+    bucket_id = (payload['bucketId'] || '').delete(' ')
+  rescue Exception => err
+    return res.json({
+      :success => false,
+      :message => 'Payload is invalid.',
+    })
+  end
+
+  if !bucket_id || bucket_id == ''
+    return res.json({
+      :success => false,
+      :message => 'bucketId was not provided.',
+    })
+  end
+
+  client
+    .set_endpoint(req.variables['APPWRITE_FUNCTION_ENDPOINT'])
+    .set_project(req.variables['APPWRITE_FUNCTION_PROJECTID'])
+    .set_key(req.variables['APPWRITE_FUNCTION_API_KEY'])
+    .set_self_signed(true)
+
+  file_list = nil
+  begin
+    file_list = storage.list_files(bucket_id: bucket_id)
+  rescue Exception => err
+    return res.json({
+      :success => false,
+      :message => 'Failed to get file list.',
+    })
+  end
+
+  file_list.files.each do |file|
+    storage.delete_file(bucket_id: bucket_id, file_id: file.id)
+  end
+
+  return res.json({
+    :success => true,
+  })
+end

--- a/ruby/wipe-appwrite-bucket/index.rb
+++ b/ruby/wipe-appwrite-bucket/index.rb
@@ -35,18 +35,25 @@ def main(req, res)
     .set_key(req.variables['APPWRITE_FUNCTION_API_KEY'])
     .set_self_signed(true)
 
-  file_list = nil
-  begin
-    file_list = storage.list_files(bucket_id: bucket_id)
-  rescue Exception => err
-    return res.json({
-      :success => false,
-      :message => 'Failed to get file list.',
-    })
-  end
+  done = false
+  while !done do
+    file_list = nil
+    begin
+      file_list = storage.list_files(bucket_id: bucket_id)
+    rescue Exception => err
+      return res.json({
+        :success => false,
+        :message => 'Failed to get file list.',
+      })
+    end
 
-  file_list.files.each do |file|
-    storage.delete_file(bucket_id: bucket_id, file_id: file.id)
+    file_list.files.each do |file|
+      storage.delete_file(bucket_id: bucket_id, file_id: file.id)
+    end
+
+    if file_list.files.count <= 0
+      done = true
+    end
   end
 
   return res.json({

--- a/ruby/wipe-appwrite-bucket/index.rb
+++ b/ruby/wipe-appwrite-bucket/index.rb
@@ -4,7 +4,7 @@ def main(req, res)
   client = Appwrite::Client.new
   storage = Appwrite::Storage.new(client)
 
-  if !req.variables['APPWRITE_FUNCTION_ENDPOINT'] or !req.variables['APPWRITE_FUNCTION_API_KEY']
+  if !req.variables['APPWRITE_FUNCTION_ENDPOINT'] or !req.variables['APPWRITE_FUNCTION_API_KEY'] or !req.variables['APPWRITE_FUNCTION_PROJECT_ID']
     return res.json({
       :success => false,
       :message => 'Environment variables are not set. Function cannot use Appwrite SDK.',
@@ -31,7 +31,7 @@ def main(req, res)
 
   client
     .set_endpoint(req.variables['APPWRITE_FUNCTION_ENDPOINT'])
-    .set_project(req.variables['APPWRITE_FUNCTION_PROJECTID'])
+    .set_project(req.variables['APPWRITE_FUNCTION_PROJECT_ID'])
     .set_key(req.variables['APPWRITE_FUNCTION_API_KEY'])
     .set_self_signed(true)
 


### PR DESCRIPTION
#### Summary
This PR adds an example for Ruby to wipe all files in an Appwrite bucket.

#### Screens
Bucket with existing files
![screen-sel-221008-1940-46](https://user-images.githubusercontent.com/12299813/194718466-b70463ea-88d0-4764-ba64-b36ee0931fa9.png)
Executing function with payload
![screen-sel-221008-1950-08](https://user-images.githubusercontent.com/12299813/194718489-5e53273e-98bb-41cc-a4f9-a7d4235fbf34.png)
Bucket after executing the function
![screen-sel-221008-1941-13](https://user-images.githubusercontent.com/12299813/194718493-d10abc6b-7edc-4093-ab3b-2c6a2217c3f4.png)
Function response
![screen-sel-221008-1941-29](https://user-images.githubusercontent.com/12299813/194718500-40f6cd7c-0c9f-44fb-afe7-27b225fd8827.png)
Function response when passing a payload without bucket id
![screen-sel-221008-1941-22](https://user-images.githubusercontent.com/12299813/194718506-d60d14ee-ddbf-4933-8021-78153f649916.png)


#### Ticket Link
Fixes https://github.com/appwrite/appwrite/issues/4139