### PR TITLE
Added wipeAppwriteCollection() Function using Ruby

### DIFF
--- a/ruby/wipe-appwrite-collection/Gemfile
+++ b/ruby/wipe-appwrite-collection/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'appwrite'

--- a/ruby/wipe-appwrite-collection/README.md
+++ b/ruby/wipe-appwrite-collection/README.md
@@ -1,0 +1,53 @@
+# 🧹 Wipe Appwrite Collection
+
+A Ruby Cloud Function that wipes all documents from an Appwrite collection.
+
+_Example input:_
+
+```json
+{
+    "databaseId":"stage",
+    "collectionId":"profiles"
+}
+```
+
+_Example output:_
+
+
+```json
+{
+    "success":true
+}
+```
+
+_Example error output:_
+
+
+```json
+{
+    "success":false,
+    "message":"databaseId was not provided."
+}
+```
+
+## 📝 Environment Variables
+
+List of environment variables used by this cloud function:
+
+- **APPWRITE_FUNCTION_ENDPOINT** - Endpoint of Appwrite project
+- **APPWRITE_FUNCTION_API_KEY** - Appwrite API Key
+- **APPWRITE_FUNCTION_PROJECT_ID** - Appwrite project ID. If running on Appwrite, this variable is provided automatically.
+
+## 🚀 Deployment
+
+There are two ways of deploying the Appwrite function, both having the same results, but each using a different process. We highly recommend using CLI deployment to achieve the best experience.
+
+### Using CLI
+
+Make sure you have [Appwrite CLI](https://appwrite.io/docs/command-line#installation) installed, and you have successfully logged into your Appwrite server. To make sure Appwrite CLI is ready, you can use the command `appwrite client --debug` and it should respond with green text `✓ Success`.
+
+Make sure you are in the same folder as your `appwrite.json` file and run `appwrite deploy function` to deploy your function. You will be prompted to select which functions you want to deploy.
+
+### Manual using tar.gz
+
+Manual deployment has no requirements and uses Appwrite Console to deploy the tag. First, enter the folder of your function. Then, create a tarball of the whole folder and gzip it. After creating `.tar.gz` file, visit Appwrite Console, click on the `Deploy Tag` button and switch to the `Manual` tab. There, set the `entrypoint` to `index.rb`, and upload the file we just generated.

--- a/ruby/wipe-appwrite-collection/index.rb
+++ b/ruby/wipe-appwrite-collection/index.rb
@@ -1,0 +1,71 @@
+require 'appwrite'
+
+def main(req, res)
+  client = Appwrite::Client.new
+  database = Appwrite::Databases.new(client)
+
+  if !req.variables['APPWRITE_FUNCTION_ENDPOINT'] or !req.variables['APPWRITE_FUNCTION_API_KEY']
+    return res.json({
+      :success => false,
+      :message => 'Environment variables are not set. Function cannot use Appwrite SDK.',
+    })
+  end
+
+  database_id = nil
+  collection_id = nil
+  begin
+    payload = JSON.parse(req.payload)
+    database_id = (payload['databaseId'] || '').delete(' ')
+    collection_id = (payload['collectionId'] || '').delete(' ')
+  rescue Exception => err
+    return res.json({
+      :success => false,
+      :message => 'Payload is invalid.',
+    })
+  end
+
+  if !database_id || database_id == ''
+    return res.json({
+      :success => false,
+      :message => 'databaseId was not provided.',
+    })
+  end
+
+  if !collection_id || collection_id == ''
+    return res.json({
+      :success => false,
+      :message => 'collectionId was not provided.',
+    })
+  end
+
+  client
+    .set_endpoint(req.variables['APPWRITE_FUNCTION_ENDPOINT'])
+    .set_project(req.variables['APPWRITE_FUNCTION_PROJECTID'])
+    .set_key(req.variables['APPWRITE_FUNCTION_API_KEY'])
+    .set_self_signed(true)
+
+  done = false
+  while !done do
+    document_list = nil
+    begin
+      document_list = database.list_documents(database_id: database_id, collection_id: collection_id)
+    rescue Exception => err
+      return res.json({
+        :success => false,
+        :message => 'Failed to get documents list.',
+      })
+    end
+
+    document_list.documents.each do |document|
+      database.delete_document(database_id: database_id, collection_id: collection_id, document_id: document.id)
+    end
+
+    if document_list.documents.count <= 0
+      done = true
+    end
+  end
+
+  return res.json({
+    :success => true,
+  })
+end


### PR DESCRIPTION
#### Summary
This PR adds an example for Ruby to wipe all documents in an Appwrite database.

#### Screens
Database with existing documents
![screen-sel-221008-2037-50](https://user-images.githubusercontent.com/12299813/194720853-bf724509-f1df-4ca5-85ec-78c07b9f2d77.png)
Executing function with payload
![screen-sel-221008-2045-59](https://user-images.githubusercontent.com/12299813/194720858-1315e776-5122-44c4-bc30-4845a4a3bf2a.png)
Database after executing function
![screen-sel-221008-2046-25](https://user-images.githubusercontent.com/12299813/194720889-1df12ff4-3f18-4f84-9179-806552ce6bd3.png)
Function response
![screen-sel-221008-2053-02](https://user-images.githubusercontent.com/12299813/194720877-c6463b11-db38-475a-b182-1464d0534c39.png)
Function response when passing a payload without database id
![screen-sel-221008-2046-43](https://user-images.githubusercontent.com/12299813/194720866-18c9da7d-72ae-4105-90a3-a392a0a08f53.png)

#### Ticket Link
Fixes https://github.com/appwrite/appwrite/issues/4101