### PR TITLE
Update PHP's Get Giphy GIF example to v2 images

### DIFF
--- a/php/generate_giphy_gif/README.md
+++ b/php/generate_giphy_gif/README.md
@@ -37,13 +37,13 @@ $ cd php/generate_giphy_gif
 
 2. Enter this function folder and build the code:
 ```
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:8.1 sh /usr/local/src/build.sh
+docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:v2-8.1 sh /usr/local/src/build.sh
 ```
 As a result, a `code.tar.gz` file will be generated.
 
 3. Start the Open Runtime:
 ```
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:8.1 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:v2-8.1 sh /usr/local/src/start.sh
 ```
 
 Your function is now listening on port `3000`, and you can execute it by sending `POST` request with appropriate authorization headers. To learn more about runtime, you can visit PHP runtime [README](https://github.com/open-runtimes/open-runtimes/tree/main/runtimes/php-8.1).

--- a/php/generate_giphy_gif/index.php
+++ b/php/generate_giphy_gif/index.php
@@ -15,22 +15,22 @@ return function ($req, $res) {
         throw new \Exception('Invalid Search Query.');
     }
 
-    // Make sure we have envirnment variables required to execute
+    // Make sure we have environment variables required to execute
     if(
-        empty($req['env']['GIPHY_API_KEY'])
+        empty($req['variables']['GIPHY_API_KEY'])
     ) {
         throw new \Exception('Please provide all required environment variables.');
     }
 
-    // Download image to buffer
-    $ch = \curl_init("https://api.giphy.com/v1/gifs/search?api_key={$req['env']['GIPHY_API_KEY']}&q={$search}&limit=1");
+    // Make GET request to api.giphy.com
+    $ch = \curl_init(\sprintf('https://api.giphy.com/v1/gifs/search?api_key=%s&q=%s&limit=1', $req['variables']['GIPHY_API_KEY'], \rawurlencode($search)));
     \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     \curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 
     $response = \json_decode(\curl_exec($ch), true);
     \curl_close($ch);
 
-    // Return phone number prefix
+    // Return the search query and the first GIF
     $res->json([
         'search' => $search,
         'gif' => $response["data"][0]['url'],


### PR DESCRIPTION
This PR updates the PHP Get Giphy GIF example to use the latest `v2-8.1` docker image and fixes an issue where the search query wasn't URL encoded causing the API request to fail sometimes.

#### Screenshot of working v2 image

![Screen Shot 2022-10-10 at 2 18 03 AM](https://user-images.githubusercontent.com/2221746/194786356-2245c8cf-6a2e-4693-aca6-8a746423106c.png)
