### PR TITLE
Update PHP's Object Detection example to v2 images

### DIFF
--- a/php/object_detection/README.md
+++ b/php/object_detection/README.md
@@ -15,12 +15,12 @@ _Example output:_
 
 ```json
 {
-    "name": "cake",
-    "confidence": 0.7977721691131592,
-    "x": 21,
-    "y": 5,
-    "width": 494,
-    "height": 333
+    "ObjectClassName": "cake",
+    "Score": 0.7977721691131592,
+    "X": 21,
+    "Y": 5,
+    "Width": 494,
+    "Height": 333
 }
 ```
 

--- a/php/object_detection/README.md
+++ b/php/object_detection/README.md
@@ -10,18 +10,27 @@ _Example input:_
 }
 ```
 
-_Example output:_
+_Example output: (Objects found)_
 
 
 ```json
 {
-    "url": "https://picsum.photos/seed/open___runtimes/1000/1000",
     "name": "cake",
     "confidence": 0.7977721691131592,
     "x": 21,
     "y": 5,
     "width": 494,
     "height": 333
+}
+```
+
+
+_Example output: (Objects not found)_
+
+
+```json
+{
+    "message": "No objects were found, try another URL.",
 }
 ```
 
@@ -41,14 +50,16 @@ $ cd php/object_detection
 ```
 
 2. Enter this function folder and build the code:
+
 ```
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:8.1 sh /usr/local/src/build.sh
+docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:v2-8.1 sh /usr/local/src/build.sh
 ```
 As a result, a `code.tar.gz` file will be generated.
 
 3. Start the Open Runtime:
+
 ```
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:8.1 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:v2-8.1 sh /usr/local/src/start.sh
 ```
 
 Your function is now listening on port `3000`, and you can execute it by sending `POST` request with appropriate authorization headers. To learn more about runtime, you can visit PHP runtime [README](https://github.com/open-runtimes/open-runtimes/tree/main/runtimes/php-8.1).

--- a/php/object_detection/README.md
+++ b/php/object_detection/README.md
@@ -10,7 +10,7 @@ _Example input:_
 }
 ```
 
-_Example output: (Objects found)_
+_Example output:_
 
 
 ```json
@@ -21,16 +21,6 @@ _Example output: (Objects found)_
     "y": 5,
     "width": 494,
     "height": 333
-}
-```
-
-
-_Example output: (Objects not found)_
-
-
-```json
-{
-    "message": "No objects were found, try another URL.",
 }
 ```
 

--- a/php/object_detection/index.php
+++ b/php/object_detection/index.php
@@ -47,16 +47,6 @@ return function ($req, $res) {
     $response = \json_decode(\curl_exec($ch), true);
     \curl_close($ch);
 
-    // cloudmersive didn't recognize any objects.
-    if (
-        $response['ObjectCount'] === 0
-    ) {
-        $res->json([
-            'message' => 'No objects were found, try another URL.'
-        ]);
-        return;
-    }
-
     // Return phone number prefix
     $res->json($response['Objects']);
 };


### PR DESCRIPTION
This PR updates the PHP Object Detection example to use the v2 image. It also includes a fix where the image couldn't be fetched if the URL is behind a proxy - like Cloudflare for instance, to get around this we add a User-Agent for a Browser, I choose Chrome here.

#### Screenshot of working v2 image

![Screen Shot 2022-10-10 at 2 56 32 AM](https://user-images.githubusercontent.com/2221746/194788253-50248204-e4f9-4b87-8569-8e0033d31243.png)

> **Note** Experimented with adding a check for no objects found but decided to revert it, returning an empty object is fine.