### PR TITLE
Fix Ruby's translate text with Google docs

### DIFF
--- a/ruby/translate-text-with-google/README.md
+++ b/ruby/translate-text-with-google/README.md
@@ -31,7 +31,7 @@ No environment variables needed.
 
 ```
 $ git clone https://github.com/open-runtimes/examples.git && cd examples
-$ cd python/convert_phone_number_to_country_name
+$ cd ruby/translate-text-with-google
 ```
 
 2. Enter this function folder and build the code:
@@ -42,12 +42,12 @@ As a result, a `code.tar.gz` file will be generated.
 
 3. Start the Open Runtime:
 ```
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.rb --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/ruby:3.1 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=YOUR_API_KEY -e INTERNAL_RUNTIME_ENTRYPOINT=index.rb --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/ruby:3.1 sh /usr/local/src/start.sh
 ```
 
-> Make sure to replace `YOUR_API_KEY` without your key.
+> Make sure to replace `YOUR_API_KEY` with your key.
 
-Your function is now listening on port `3000`, and you can execute it by sending `POST` request with appropriate authorization headers. To learn more about runtime, you can visit Python runtime [README](https://github.com/open-runtimes/open-runtimes/tree/main/runtimes/ruby-3.1).
+Your function is now listening on port `3000`, and you can execute it by sending `POST` request with appropriate authorization headers. To learn more about runtime, you can visit Ruby runtime [README](https://github.com/open-runtimes/open-runtimes/tree/main/runtimes/ruby-3.1).
 
 ## 📝 Notes
  - This function is designed for use with Appwrite Cloud Functions. You can learn more about it in [Appwrite docs](https://appwrite.io/docs/functions).


### PR DESCRIPTION
This commit fixes copy issues:
- Some places where it should read Ruby and instead was Python
- An incorrect path
- A place where it should read with and instead was without
- There was a warning pointing to replace a value that was set with another name