### PR TITLE
Added send_http_function example using Dart

### DIFF
--- a/dart/send_http_request/README.md
+++ b/dart/send_http_request/README.md
@@ -1,0 +1,67 @@
+# 🌐 Sending HTTP Request
+
+A Dart Cloud Function for sending HTTP request.
+
+_Example input 1:_
+
+```json
+{
+    "url": "https://catfact.ninja/fact",
+    "method": "GET", 
+    "headers": {},
+    "body": ""
+}
+```
+
+_Example output 1:_
+
+```json
+{"success":true,"response":{"headers":{...},"code":200,"body": {"fact":"Cats must have fat in their diet because they can't produce it on their own.","length":76}}}
+```
+
+_Example input 2:_
+
+```json
+{
+    "url": "https://demo.appwrite.io/v1/locale/countries/eu",
+    "method": "GET", 
+    "headers": {"x-client-version":"1.0.0"},
+    "body": ""
+}
+```
+
+_Example output 2:_
+
+```json
+{"success":true,"response":{"headers":{...},"code":200,"body": {"total":27,"countries":[]}}}
+```
+
+## 🚀 Deployment
+
+1. Clone this repository, and enter this function folder:
+
+```
+git clone https://github.com/open-runtimes/examples.git && cd examples
+cd dart/send_http_request
+```
+
+2. Enter this function folder and build the code:
+
+```
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=lib/main.dart --rm --interactive --tty --volume $PWD:/usr/code openruntimes/dart:v2-2.17 sh /usr/local/src/build.sh
+```
+
+As a result, a `code.tar.gz` file will be generated.
+
+3. Start the Open Runtime:
+
+```
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/dart:v2-2.17 sh /usr/local/src/start.sh
+```
+
+Your function is now listening on port `3000`, and you can execute it by sending `POST` request with appropriate authorization headers. To learn more about runtime, you can visit Dart runtime [README](https://github.com/open-runtimes/open-runtimes/tree/main/runtimes/dart-2.17).
+
+## 📝 Notes
+
+- This function is designed for use with Appwrite Cloud Functions. You can learn more about it in [Appwrite docs](https://appwrite.io/docs/functions).
+- This example is compatible with Dart 2.15, 2.16 and 2.17. Other versions may work but are not guaranteed to work as they haven't been tested.

--- a/dart/send_http_request/lib/main.dart
+++ b/dart/send_http_request/lib/main.dart
@@ -1,0 +1,71 @@
+import "dart:convert";
+
+import "package:dio/dio.dart";
+
+Future<void> sendHttpRequest(final res, String url, String method, Map<String, dynamic> headers, String body) async {
+  try {
+    final dio = Dio();
+    RequestOptions requestOptions = RequestOptions(path: url.trim(), method: method, headers: headers, data: body);
+
+    var response = await dio.fetch(requestOptions);
+
+    if (response.statusCode == 200) {
+      markSuccess(res, {
+        "headers": response.headers.map,
+        "code": 200,
+        "body": response.data,
+      });
+      return;
+    } else {
+      markFailure(res, "URL could not be reached"); // Response message could be changed based on code received.
+    }
+  } catch (e) {
+    markFailure(res, "URL could not be reached");
+  }
+}
+
+/// Sends a response back to user indicating a failure.
+
+void markFailure(final res, final message) {
+  res.json({
+    "success": false,
+    "message": message,
+  });
+}
+
+/// Sends a response back to user indicating a success along with [response].
+/// [response] includes response headers, response code and response data.
+
+void markSuccess(final res, final response) {
+  res.json({
+    "success": true,
+    "response": response,
+  });
+}
+
+Future<void> start(final req, final res) async {
+  String url = "";
+  String method = "";
+  Map<String, dynamic> headers;
+  String body;
+
+  try {
+    final payload = jsonDecode(req.payload);
+    url = payload["url"] ?? '';
+    method = payload["method"] ?? '';
+    headers = payload["headers"] != null ? Map<String, dynamic>.from(payload["headers"]) : {};
+    body = payload["body"] ?? '';
+
+    /// [url] and [method] are mandatory to send HTTP request.
+    /// If any of the two isEmpty, then throw Error and terminate further code execution.
+
+    if (url.isEmpty || method.isEmpty) {
+      throw Error();
+    }
+  } catch (_) {
+    markFailure(res, "Payload is invalid");
+    return;
+  }
+
+  await sendHttpRequest(res, url, method, headers, body);
+}

--- a/dart/send_http_request/pubspec.yaml
+++ b/dart/send_http_request/pubspec.yaml
@@ -1,0 +1,9 @@
+name: send_http_request
+description: An example code to send HTTP request by @Yavnik.
+version: 1.0.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies: 
+  dio: ^5.2.0


### PR DESCRIPTION
Screenshot showing successful function execution when called from Dart code.

![send_http_function_screenshot](https://github.com/open-runtimes/examples/assets/17024368/df9d600a-3842-46c6-96ca-156bfc40c14b)
(Key has been deleted)

Closes https://github.com/appwrite/appwrite/issues/4173
